### PR TITLE
Gracefully handle a newly initialize git repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,10 @@ func loadGitInfo(currentDirectory string, templateContext *TemplateContext) erro
 	} else if repo != nil {
 		head, err := repo.Head()
 		if err != nil {
+			if err.Error() == "reference not found" {
+				templateContext.GitBranch = "no-ref"
+				return nil
+			}
 			return fmt.Errorf("failed to get repo head: %w", err)
 		}
 		templateContext.GitBranch = head.Name().Short()


### PR DESCRIPTION
If the directory is newly initialized but doesn't yet have a branch, the output error's with

```
2023-09-03T12:36:26.450-0500    FATAL   Failed loading git info {"error": "failed to get repo head: reference not found"}
```